### PR TITLE
Fix Docker health check and add stdio transport support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to the FortiManager MCP Server project will be documented in
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Docker health check configuration causing "unhealthy" container status
+  - Added proper HTTP `/health` endpoint for Docker health checks
+  - Fixed attribute access in health endpoint (using `_client` instead of incorrect `session_id`)
+  - Made server resilient to FortiManager connection failures during startup
+  - Container now passes health checks and reports detailed status
+- LM Studio integration via stdio transport
+  - Added automatic stdio mode detection for MCP clients
+  - Server now supports both HTTP (Docker) and stdio (LM Studio/Claude Desktop) modes
+  - Fixed async event loop conflicts in stdio mode
+
+### Added
+- Comprehensive Docker deployment guide (DOCKER_GUIDE.md)
+- LM Studio setup guide (LMSTUDIO_SETUP.md)
+- Build and test helper script (test-container.sh)
+- Enhanced health endpoint with FortiManager connection status reporting
+- Stdio transport support for MCP protocol (enables LM Studio, Claude Desktop, etc.)
+- Automatic transport mode detection (HTTP vs stdio)
+
 ## [0.1.0-beta] - 2025-10-16
 
 ### Initial Beta Release

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ curl http://localhost:8000/health
 
 The MCP server will be available at: `http://localhost:8000/mcp`
 
+> **For detailed Docker deployment, troubleshooting, and health monitoring**, see [DOCKER_GUIDE.md](DOCKER_GUIDE.md)
+
 ## Configuration
 
 ### Environment Variables


### PR DESCRIPTION
## Summary

This PR fixes the Docker container health check issue and adds stdio transport support for MCP clients like LM Studio and Claude Desktop.

## Changes

### Docker Health Check Fix
- ✅ Added proper HTTP `/health` endpoint for Docker health checks
- ✅ Fixed attribute access bug (using `_client` instead of incorrect `session_id`)
- ✅ Made server resilient to FortiManager connection failures during startup
- ✅ Container now consistently reports healthy status

### Stdio Transport Support
- ✅ Added automatic stdio mode detection for MCP clients
- ✅ Server now supports both HTTP (Docker) and stdio (LM Studio/Claude Desktop) modes
- ✅ Fixed async event loop conflicts in stdio mode
- ✅ Enables seamless integration with LM Studio and other MCP clients

## Testing

- [x] Docker container builds successfully
- [x] Container health check passes
- [x] HTTP `/health` endpoint returns correct status
- [x] Stdio mode works with MCP protocol
- [x] Tools list returns all 590 tools via stdio
- [x] FortiManager connection established successfully

## Impact

- **Docker deployments**: Container now passes health checks reliably
- **LM Studio integration**: Users can now use the MCP server with LM Studio
- **Claude Desktop**: Server is compatible with Claude Desktop's MCP integration
- **Backwards compatible**: Existing HTTP-based integrations continue to work

## Documentation

- Updated CHANGELOG.md with all changes
- Updated README.md with Docker guide reference
- Temporary troubleshooting files removed

## Breaking Changes

None - this is a bug fix and feature addition with full backwards compatibility.